### PR TITLE
Fix deletion bug

### DIFF
--- a/MindGear_iOS/MindGear_iOS/ContentView.swift
+++ b/MindGear_iOS/MindGear_iOS/ContentView.swift
@@ -48,7 +48,7 @@ struct ContentView: View {
 
     private func deleteItems(offsets: IndexSet) {
         withAnimation {
-            for index in offsets {
+            for index in offsets.sorted(by: >) {
                 modelContext.delete(items[index])
             }
         }


### PR DESCRIPTION
## Summary
- iterate through deletion offsets in descending order to avoid crashes

## Testing
- `swiftc -emit-sil MindGear_iOS/MindGear_iOS/*.swift` *(fails: no such module SwiftUI)*

------
https://chatgpt.com/codex/tasks/task_e_685a9edbbdd88329a8df2238d92c1712