### PR TITLE
Add SettingsView with local settings

### DIFF
--- a/MindGear_iOS/MindGear_iOS/ViewModels/SettingsViewModel.swift
+++ b/MindGear_iOS/MindGear_iOS/ViewModels/SettingsViewModel.swift
@@ -1,0 +1,23 @@
+import Foundation
+import Combine
+
+class SettingsViewModel: ObservableObject {
+    @Published var username: String {
+        didSet {
+            UserDefaults.standard.set(username, forKey: Self.usernameKey)
+        }
+    }
+    @Published var notificationsEnabled: Bool {
+        didSet {
+            UserDefaults.standard.set(notificationsEnabled, forKey: Self.notificationsKey)
+        }
+    }
+
+    private static let usernameKey = "username"
+    private static let notificationsKey = "notificationsEnabled"
+
+    init() {
+        self.username = UserDefaults.standard.string(forKey: Self.usernameKey) ?? ""
+        self.notificationsEnabled = UserDefaults.standard.bool(forKey: Self.notificationsKey)
+    }
+}

--- a/MindGear_iOS/MindGear_iOS/Views/MainTabView.swift
+++ b/MindGear_iOS/MindGear_iOS/Views/MainTabView.swift
@@ -28,6 +28,12 @@ struct MainTabView: View {
                     Image(systemName: "heart.fill")
                     Text("Favoriten")
                 }
+
+            SettingsView()
+                .tabItem {
+                    Image(systemName: "gearshape.fill")
+                    Text("Einstellungen")
+                }
         }
     }
 }

--- a/MindGear_iOS/MindGear_iOS/Views/SettingsView.swift
+++ b/MindGear_iOS/MindGear_iOS/Views/SettingsView.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @StateObject private var viewModel = SettingsViewModel()
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section(header: Text("Profil")) {
+                    TextField("Benutzername", text: $viewModel.username)
+                }
+
+                Section(header: Text("Benachrichtigungen")) {
+                    Toggle("Aktivieren", isOn: $viewModel.notificationsEnabled)
+                }
+            }
+            .navigationTitle("Einstellungen")
+        }
+    }
+}
+
+#Preview {
+    SettingsView()
+}


### PR DESCRIPTION
## Summary
- add new SettingsViewModel to manage username and notifications in UserDefaults
- implement SettingsView with placeholders for profile and notifications
- connect SettingsView in MainTabView via a new tab

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688788f13f4883298e947f0fb2f887c9