### PR TITLE
Add offline favorite support

### DIFF
--- a/MindGearTests/FavoritesManagerTests.swift
+++ b/MindGearTests/FavoritesManagerTests.swift
@@ -13,18 +13,18 @@ final class FavoritesManagerTests: XCTestCase {
         context = ModelContext(container)
     }
 
-    func testToggleAndFetchFavorites() throws {
+    func testToggleAndFetchFavorites() async throws {
         let video = Video(id: UUID(), title: "t", description: "d", thumbnailURL: "u", videoURL: "v", category: "c")
         let manager = FavoritesManager.shared
 
         XCTAssertFalse(manager.isFavorite(video: video, context: context))
-        manager.toggleFavorite(video: video, context: context)
+        await manager.toggleFavorite(video: video, context: context)
         XCTAssertTrue(manager.isFavorite(video: video, context: context))
 
         let all = manager.getAllFavorites(context: context)
         XCTAssertEqual(all.count, 1)
 
-        manager.toggleFavorite(video: video, context: context)
+        await manager.toggleFavorite(video: video, context: context)
         XCTAssertFalse(manager.isFavorite(video: video, context: context))
         XCTAssertTrue(manager.getAllFavorites(context: context).isEmpty)
     }

--- a/MindGear_iOS/MindGear_iOS/Manager/FavoritesManager.swift
+++ b/MindGear_iOS/MindGear_iOS/Manager/FavoritesManager.swift
@@ -16,25 +16,35 @@ final class FavoritesManager {
         }
     }
 
-    func toggleFavorite(video: Video, context: ModelContext) {
+    func toggleFavorite(video: Video, context: ModelContext) async {
         do {
             let results = try context.fetch(FetchDescriptor<FavoriteVideoEntity>())
             if let existing = results.first(where: { $0.id == video.id }) {
                 context.delete(existing)
             } else {
+                var data: Data? = nil
+                if let url = URL(string: video.thumbnailURL) {
+                    data = try? await downloadThumbnail(from: url)
+                }
                 let favorite = FavoriteVideoEntity(
                     id: video.id,
                     title: video.title,
                     videoDescription: video.description,
                     thumbnailURL: video.thumbnailURL,
                     videoURL: video.videoURL,
-                    category: video.category
+                    category: video.category,
+                    thumbnailData: data
                 )
                 context.insert(favorite)
             }
         } catch {
             print("Error toggling favorite: \(error)")
         }
+    }
+
+    private func downloadThumbnail(from url: URL) async throws -> Data {
+        let (data, _) = try await URLSession.shared.data(from: url)
+        return data
     }
 
     func getAllFavorites(context: ModelContext) -> [FavoriteVideoEntity] {

--- a/MindGear_iOS/MindGear_iOS/SwiftData/FavoriteVideoEntity.swift
+++ b/MindGear_iOS/MindGear_iOS/SwiftData/FavoriteVideoEntity.swift
@@ -16,13 +16,15 @@ final class FavoriteVideoEntity {
     var thumbnailURL: String
     var videoURL: String
     var category: String
+    var thumbnailData: Data?
 
-    init(id: UUID, title: String, videoDescription: String, thumbnailURL: String, videoURL: String, category: String) {
+    init(id: UUID, title: String, videoDescription: String, thumbnailURL: String, videoURL: String, category: String, thumbnailData: Data? = nil) {
         self.id = id
         self.title = title
         self.videoDescription = videoDescription
         self.thumbnailURL = thumbnailURL
         self.videoURL = videoURL
         self.category = category
+        self.thumbnailData = thumbnailData
     }
 }

--- a/MindGear_iOS/MindGear_iOS/ViewModels/FavoritenViewModel.swift
+++ b/MindGear_iOS/MindGear_iOS/ViewModels/FavoritenViewModel.swift
@@ -19,8 +19,8 @@ class FavoritenViewModel: ObservableObject {
         favorites = FavoritesManager.shared.getAllFavorites(context: context)
     }
 
-    func toggleFavorite(video: Video, context: ModelContext) {
-        FavoritesManager.shared.toggleFavorite(video: video, context: context)
+    func toggleFavorite(video: Video, context: ModelContext) async {
+        await FavoritesManager.shared.toggleFavorite(video: video, context: context)
         loadFavorites(context: context)
     }
 

--- a/MindGear_iOS/MindGear_iOS/ViewModels/VideoListView.swift
+++ b/MindGear_iOS/MindGear_iOS/ViewModels/VideoListView.swift
@@ -1,7 +1,13 @@
 import SwiftUI
+import SwiftData
 
 struct VideoListView: View {
-    @StateObject private var viewModel = VideoViewModel()
+    @Environment(\.modelContext) private var context
+    @StateObject private var viewModel: VideoViewModel
+
+    init() {
+        _viewModel = StateObject(wrappedValue: VideoViewModel(context: nil))
+    }
 
     var body: some View {
         NavigationView {
@@ -57,6 +63,7 @@ struct VideoListView: View {
             }
             .searchable(text: $viewModel.searchText, prompt: "Suche Videos")
             .task {
+                viewModel.updateContext(context)
                 await viewModel.loadVideos()
             }
             .alert(
@@ -77,6 +84,16 @@ struct VideoListView: View {
                         })
                     )
                 }
+            )
+            .overlay(
+                Group {
+                    if let message = viewModel.offlineMessage {
+                        Text(message)
+                            .font(.footnote)
+                            .foregroundColor(.secondary)
+                            .padding(.top, 8)
+                    }
+                }, alignment: .top
             )
         }
     }


### PR DESCRIPTION
## Summary
- allow storing thumbnail data in `FavoriteVideoEntity`
- download thumbnail when toggling favorite
- use local favorites when network fails
- display offline indicator in video list
- load local thumbnails in favourites view
- update unit tests for async toggle

## Testing
- `swift test -v` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68878a68d19c8329a399f82c7a8ca80d