### PR TITLE
Add unit tests and API base URL configuration

### DIFF
--- a/MindGear_iOS/MindGear_iOS/Config.plist
+++ b/MindGear_iOS/MindGear_iOS/Config.plist
@@ -4,9 +4,11 @@
 <dict>
 	<key>RECOMMENDED_PLAYLIST</key>
 	<string>PLkL7BvJXiqSSAplLnPAyhA13Hk2rQQDmo</string>
-	<key>YOUTUBE_API_KEY</key>
-	<string>AIzaSyDOl0c6scnoCOouZvf9Rsynzac4O30_Sb4</string>
-	<key>CHRISWILLX_CHANNEL_ID</key>
+        <key>YOUTUBE_API_KEY</key>
+        <string>AIzaSyDOl0c6scnoCOouZvf9Rsynzac4O30_Sb4</string>
+        <key>API_BASE_URL</key>
+        <string>https://www.googleapis.com/youtube/v3</string>
+        <key>CHRISWILLX_CHANNEL_ID</key>
 	<string>UCmblfJ2d1yQfLrNlVJXL7Zw</string>
 	<key>CHRISWILLX_PLAYLIST</key>
 	<string>PLkL7BvJXiqSQu3i72hSrG4vUkDuaneHuB</string>

--- a/MindGear_iOS/MindGear_iOS/Manager/ConfigManager.swift
+++ b/MindGear_iOS/MindGear_iOS/Manager/ConfigManager.swift
@@ -15,6 +15,15 @@ struct ConfigManager {
         getValue(for: "YOUTUBE_API_KEY")
     }
 
+    /// Basis-URL für API-Aufrufe, aus der Config gelesen
+    static func apiBaseURL() -> URL {
+        let urlString = getValue(for: "API_BASE_URL")
+        guard let url = URL(string: urlString), !urlString.isEmpty else {
+            fatalError("❌ API_BASE_URL ungültig oder fehlt in Config.plist")
+        }
+        return url
+    }
+
     /// Einheitlicher Resolver (portfolio-clean): nutzt ausschließlich `YOUTUBE_API_KEY` aus Config.plist
     static var resolvedYouTubeAPIKey: String {
         getValue(for: "YOUTUBE_API_KEY")

--- a/MindGear_iOSTests/ConfigManagerTests.swift
+++ b/MindGear_iOSTests/ConfigManagerTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+@testable import MindGear_iOS
+
+final class ConfigManagerTests: XCTestCase {
+    func testConfigProvidesValues() {
+        // When
+        let playlistId = ConfigManager.recommendedPlaylistId
+        let url = ConfigManager.apiBaseURL()
+
+        // Then
+        XCTAssertFalse(playlistId.isEmpty, "recommendedPlaylistId sollte nicht leer sein")
+        XCTAssertNotNil(url.scheme, "apiBaseURL() sollte eine gültige URL liefern")
+    }
+}

--- a/MindGear_iOSTests/FavoritesManagerTests.swift
+++ b/MindGear_iOSTests/FavoritesManagerTests.swift
@@ -36,4 +36,15 @@ final class FavoritesManagerTests: XCTestCase {
         // Then
         XCTAssertTrue(secondInstance.isFavorite(testID), "Favoriten sollten über Instanzen hinweg erhalten bleiben")
     }
+
+    func testAllReturnsExactIDs() {
+        // Given
+        let ids = ["1", "2", "3"]
+
+        // When
+        ids.forEach { manager.toggle($0) }
+
+        // Then
+        XCTAssertEqual(Set(manager.all()), Set(ids), "all() sollte genau die hinzugefügten IDs enthalten")
+    }
 }

--- a/MindGear_iOSTests/MentorSearchTests.swift
+++ b/MindGear_iOSTests/MentorSearchTests.swift
@@ -10,14 +10,19 @@ final class MentorSearchTests: XCTestCase {
             Mentor(id: "3", name: "Charlie", profileImageURL: nil, bio: nil, playlists: nil, socials: nil)
         ]
 
-        // When & Then
+        // When
         let all = filterMentors(mentors, query: "   ")
+        // Then
         XCTAssertEqual(all.count, mentors.count, "Leere Suche sollte alle Mentoren zurückgeben")
 
+        // When
         let caseInsensitive = filterMentors(mentors, query: "alice")
+        // Then
         XCTAssertEqual(caseInsensitive.map { $0.name }, ["Alice"], "Suche sollte case-insensitive sein")
 
+        // When
         let substring = filterMentors(mentors, query: "Li")
+        // Then
         XCTAssertEqual(substring.map { $0.name }, ["Alice"], "Substring-Treffer sollten genügen")
     }
 }


### PR DESCRIPTION
## Summary
- expand `ConfigManager` with `apiBaseURL()` and corresponding plist key
- cover favorites listing and mentor filtering logic with unit tests
- ensure config values like `recommendedPlaylistId` are present and valid

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b8463ab6948329b94c421e9516f16a